### PR TITLE
feature/PP-171

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@rsksmart/rif-relay-contracts": "0.0.2-alpha.4",
     "@rsksmart/rif-relay-common": "0.0.2-alpha.5",
     "loglevel": "^1.8.0",
+    "ethereumjs-tx": "~2.1.2",
     "web3": "1.2.6",
     "web3-core": "1.2.6",
     "web3-eth": "1.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rif-relay-sdk",
-  "version": "0.0.1-alpha.5",
+  "version": "0.0.1-alpha.6",
   "description": "This project contains the SDK of the relaying services system.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -27,9 +27,9 @@
     ]
   },
   "dependencies": {
-    "@rsksmart/rif-relay-client": "0.0.2-alpha.3",
+    "@rsksmart/rif-relay-client": "0.0.2-alpha.4",
     "@rsksmart/rif-relay-contracts": "0.0.2-alpha.4",
-    "@rsksmart/rif-relay-common": "0.0.2-alpha.4",
+    "@rsksmart/rif-relay-common": "0.0.2-alpha.5",
     "loglevel": "^1.8.0",
     "web3": "1.2.6",
     "web3-core": "1.2.6",

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,10 @@ import {
     SmartWallet,
     SmartWalletDeploymentOptions
 } from './interfaces';
-import { EnvelopingConfig, EnvelopingTransactionDetails } from '@rsksmart/rif-relay-common';
+import {
+    EnvelopingConfig,
+    EnvelopingTransactionDetails
+} from '@rsksmart/rif-relay-common';
 import { RelayingResult } from '@rsksmart/rif-relay-client';
 
 interface RelayingServices {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
  */
 import { TransactionReceipt } from 'web3-core';
 import { DefaultRelayingServices } from './sdk';
+import { PrefixedHexString } from 'ethereumjs-tx';
 import {
     RelayGasEstimationOptions,
     RelayingServicesAddresses,
@@ -11,7 +12,7 @@ import {
     SmartWallet,
     SmartWalletDeploymentOptions
 } from './interfaces';
-import { EnvelopingConfig } from '@rsksmart/rif-relay-common';
+import { EnvelopingConfig, EnvelopingTransactionDetails } from '@rsksmart/rif-relay-common';
 import { RelayingResult } from '@rsksmart/rif-relay-client';
 
 interface RelayingServices {
@@ -134,9 +135,9 @@ interface RelayingServices {
      * @param initialBackoff initial time to wait before each retry, this time would be double on each attemp
      */
     getTransactionReceipt(
-        transactionHash: string,
-        retries: number,
-        initialBackoff: number
+        transactionHash: PrefixedHexString,
+        retries?: number,
+        initialBackoff?: number
     ): Promise<TransactionReceipt>;
 }
 
@@ -148,5 +149,8 @@ export {
     RelayingTransactionOptions,
     RelayGasEstimationOptions,
     SmartWalletDeploymentOptions,
-    RelayingServicesAddresses
+    RelayingServicesAddresses,
+    RelayingResult,
+    EnvelopingTransactionDetails,
+    EnvelopingConfig
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
     SmartWalletDeploymentOptions
 } from './interfaces';
 import { EnvelopingConfig } from '@rsksmart/rif-relay-common';
+import { RelayingResult } from '@rsksmart/rif-relay-client';
 
 interface RelayingServices {
     /**
@@ -69,7 +70,7 @@ interface RelayingServices {
      */
     relayTransaction(
         options: RelayingTransactionOptions
-    ): Promise<TransactionReceipt>;
+    ): Promise<RelayingResult>;
 
     /**
      * It checks if the provided tokenAddress is allowed by the rif relay verifiers.

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,6 +125,19 @@ interface RelayingServices {
     estimateMaxPossibleRelayGasWithLinearFit(
         options: RelayGasEstimationOptions
     ): Promise<string>;
+
+    /**
+     * It
+     *
+     * @param transactionHash transaction hash to look for the receipt
+     * @param retries amount of times that would retry for the receipt
+     * @param initialBackoff initial time to wait before each retry, this time would be double on each attemp
+     */
+    getTransactionReceipt(
+        transactionHash: string,
+        retries: number,
+        initialBackoff: number
+    ): Promise<TransactionReceipt>;
 }
 
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,8 @@ interface RelayingServices {
      * will be subsidized.
      */
     relayTransaction(
-        options: RelayingTransactionOptions
+        options: RelayingTransactionOptions,
+        nonBlock?: boolean
     ): Promise<TransactionReceipt>;
 
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,7 +127,7 @@ interface RelayingServices {
     ): Promise<string>;
 
     /**
-     * It
+     * It looks for the transaction receipt of a transaction hash
      *
      * @param transactionHash transaction hash to look for the receipt
      * @param retries amount of times that would retry for the receipt

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,8 +68,7 @@ interface RelayingServices {
      * will be subsidized.
      */
     relayTransaction(
-        options: RelayingTransactionOptions,
-        nonBlock?: boolean
+        options: RelayingTransactionOptions
     ): Promise<TransactionReceipt>;
 
     /**

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -57,7 +57,6 @@ export interface RelayingTransactionOptions {
     value?: number;
     onlyPreferredRelays?: boolean;
     tokenAddress: string;
-    waitForTransactionReceipt?: boolean;
 }
 
 export interface RelayGasEstimationOptions {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -24,6 +24,7 @@ export interface SmartWalletDeploymentOptions {
     onlyPreferredRelays?: boolean;
     callVerifier?: string;
     callForwarder?: string;
+    transactionDetails?: Partial<EnvelopingTransactionDetails>;
 }
 
 export interface RelayingServicesConfiguration {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -57,6 +57,7 @@ export interface RelayingTransactionOptions {
     value?: number;
     onlyPreferredRelays?: boolean;
     tokenAddress: string;
+    waitForTransactionReceipt?: boolean;
 }
 
 export interface RelayGasEstimationOptions {

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1,5 +1,6 @@
 import { RelayingServices } from './index';
 import { Account, HttpProvider, TransactionReceipt } from 'web3-core';
+import { PrefixedHexString } from 'ethereumjs-tx';
 import {
     EnvelopingConfig,
     EnvelopingTransactionDetails,
@@ -214,7 +215,8 @@ export class DefaultRelayingServices implements RelayingServices {
             recovererAddress,
             onlyPreferredRelays,
             callVerifier,
-            callForwarder
+            callForwarder,
+            transactionDetails
         } = options;
 
         log.debug('Checking if the wallet already exists');
@@ -241,7 +243,8 @@ export class DefaultRelayingServices implements RelayingServices {
             recoverer: recovererAddress ?? ZERO_ADDRESS,
             isSmartWalletDeploy: true,
             onlyPreferredRelays: onlyPreferredRelays || true,
-            smartWalletAddress: address
+            smartWalletAddress: address,
+            ...transactionDetails
         };
 
         const relayingResult: RelayingResult =
@@ -483,9 +486,9 @@ export class DefaultRelayingServices implements RelayingServices {
     }
 
     async getTransactionReceipt(
-        transactionHash: string,
-        retries: number,
-        initialBackoff: number
+        transactionHash: PrefixedHexString,
+        retries?: number,
+        initialBackoff?: number
     ): Promise<TransactionReceipt> {
         return await this.relayProvider.relayClient.getTransactionReceipt(
             transactionHash,

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -300,7 +300,8 @@ export class DefaultRelayingServices implements RelayingServices {
     }
 
     async relayTransaction(
-        options: RelayingTransactionOptions
+        options: RelayingTransactionOptions,
+        nonBlock?: boolean
     ): Promise<TransactionReceipt> {
         log.debug('relayTransaction Params', {
             options
@@ -364,7 +365,8 @@ export class DefaultRelayingServices implements RelayingServices {
                             jsonrpc.result
                         );
                         resolve(recipient);
-                    }
+                    },
+                    nonBlock
                 );
             }
         );

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -31,8 +31,6 @@ export class DefaultRelayingServices implements RelayingServices {
     private developmentAccounts: string[]; //code should be the same for develop and prod
     private relayProvider: RelayProvider;
     private contracts: Contracts;
-    private contractAddresses: RelayingServicesAddresses;
-    private envelopingConfig: EnvelopingConfig;
 
     private txId = 777;
 
@@ -482,6 +480,18 @@ export class DefaultRelayingServices implements RelayingServices {
                 relayWorker
             );
         return this.calculateCostFromGas(maxPossibleGasValue);
+    }
+
+    async getTransactionReceipt(
+        transactionHash: string,
+        retries: number,
+        initialBackoff: number
+    ): Promise<TransactionReceipt> {
+        return await this.relayProvider.relayClient.getTransactionReceipt(
+            transactionHash,
+            retries,
+            initialBackoff
+        );
     }
 
     private async calculateCostFromGas(gas: number) {

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -300,8 +300,7 @@ export class DefaultRelayingServices implements RelayingServices {
     }
 
     async relayTransaction(
-        options: RelayingTransactionOptions,
-        nonBlock?: boolean
+        options: RelayingTransactionOptions
     ): Promise<TransactionReceipt> {
         log.debug('relayTransaction Params', {
             options
@@ -314,7 +313,8 @@ export class DefaultRelayingServices implements RelayingServices {
             transactionDetails,
             value,
             onlyPreferredRelays,
-            tokenAddress
+            tokenAddress,
+            waitForTransactionReceipt
         } = options;
 
         log.debug('Checking if the wallet exists');
@@ -347,6 +347,7 @@ export class DefaultRelayingServices implements RelayingServices {
                         tokenAmount ? tokenAmount.toString() : '0'
                     ),
                     onlyPreferredRelays: onlyPreferredRelays ?? true,
+                    waitForTransactionReceipt,
                     ...transactionDetails
                 }
             ]
@@ -365,8 +366,7 @@ export class DefaultRelayingServices implements RelayingServices {
                             jsonrpc.result
                         );
                         resolve(recipient);
-                    },
-                    nonBlock
+                    }
                 );
             }
         );

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -6,8 +6,10 @@ import {
     TransactionConfig,
     TransactionReceipt
 } from 'web3-core';
+import { Transaction } from 'ethereumjs-tx';
 import { Web3MockConfiguration } from './mock';
 import { ZERO_ADDRESS } from '../src/constants';
+import { RelayingResult } from '../src';
 
 export const MOCK_TOKEN_ADDRESS = '0x0E569743F573323F430B6E14E5676EB0cCAd03D9';
 export const MOCK_SMART_WALLET_ADDRESS =
@@ -82,4 +84,11 @@ export const MOCK_TRANSACTION_RECEIPT: TransactionReceipt = {
         '0xfcf691fdfca9451aaed385c4be93212effff68bdb7a78c9e0c0c4676cdd55ccd',
     contractAddress: MOCK_CONTRACT_ADDRESS,
     logs: []
+};
+
+export const MOCK_RELAYING_RESULT: RelayingResult = {
+    transaction: new Transaction(),
+    receipt: MOCK_TRANSACTION_RECEIPT,
+    relayingErrors: new Map<string, Error>(),
+    pingErrors: new Map<string, Error>()
 };

--- a/test/mock.ts
+++ b/test/mock.ts
@@ -14,7 +14,6 @@ import {
     MOCK_CODE,
     MOCK_RELAYING_RESULT,
     MOCK_SMART_WALLET_ADDRESS,
-    MOCK_TRANSACTION_HASH,
     MOCK_TRANSACTION_RECEIPT
 } from './constants';
 import { Account, TransactionReceipt } from 'web3-core';

--- a/test/mock.ts
+++ b/test/mock.ts
@@ -1,4 +1,4 @@
-import { DefaultRelayingServices } from '../src';
+import { DefaultRelayingServices, RelayingResult } from '../src';
 import Web3 from 'web3';
 import {
     EnvelopingConfig,
@@ -12,6 +12,7 @@ import {
     EMPTY_CODE,
     MOCK_ADDRESS,
     MOCK_CODE,
+    MOCK_RELAYING_RESULT,
     MOCK_SMART_WALLET_ADDRESS,
     MOCK_TRANSACTION_HASH,
     MOCK_TRANSACTION_RECEIPT
@@ -168,17 +169,17 @@ export class MockContracts extends Contracts {
 export class MockRelayProvider {
     deploySmartWallet(
         transactionDetails: EnvelopingTransactionDetails
-    ): Promise<string> {
+    ): Promise<RelayingResult> {
         console.debug('deploySmartWallet', {
             transactionDetails
         });
-        return Promise.resolve(MOCK_TRANSACTION_HASH);
+        return Promise.resolve(MOCK_RELAYING_RESULT);
     }
     async _ethSendTransaction() {
         console.debug('_ethSendTransaction');
         return {
             call: () => {
-                return MOCK_TRANSACTION_RECEIPT;
+                return MOCK_RELAYING_RESULT;
             }
         };
     }

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -8,7 +8,6 @@ import {
     MOCK_CONTRACT_ADDRESS,
     MOCK_SMART_WALLET_ADDRESS,
     MOCK_TOKEN_ADDRESS,
-    MOCK_TRANSACTION_HASH,
     MOCK_RELAYING_RESULT
 } from './constants';
 import { MockRelayingServices, Web3EthMock, Web3UtilsMock } from './mock';

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -1,6 +1,6 @@
 import Web3 from 'web3';
 import { TransactionConfig } from 'web3-core';
-import { RelayingServices, SmartWallet } from '../src';
+import { RelayingResult, RelayingServices, SmartWallet } from '../src';
 import { RelayingTransactionOptions } from '../src/interfaces';
 import {
     MOCK_ACCOUNT,
@@ -8,7 +8,8 @@ import {
     MOCK_CONTRACT_ADDRESS,
     MOCK_SMART_WALLET_ADDRESS,
     MOCK_TOKEN_ADDRESS,
-    MOCK_TRANSACTION_HASH
+    MOCK_TRANSACTION_HASH,
+    MOCK_RELAYING_RESULT
 } from './constants';
 import { MockRelayingServices, Web3EthMock, Web3UtilsMock } from './mock';
 import Expect = jest.Expect;
@@ -150,12 +151,14 @@ describe('SDK not deployed tests', () => {
                 tokenAddress: MOCK_TOKEN_ADDRESS
             }
         );
+        const relayingResult: RelayingResult = MOCK_RELAYING_RESULT;
+        const txHash: string = relayingResult.transaction
+            .hash(true)
+            .toString('hex');
         expect(smartWallet.address).toBe(MOCK_SMART_WALLET_ADDRESS);
         expect(smartWallet.index).toBe(0);
         expect(smartWallet.deployment.tokenAddress).toBe(MOCK_TOKEN_ADDRESS);
-        expect(smartWallet.deployment.deployTransaction).toBe(
-            MOCK_TRANSACTION_HASH
-        );
+        expect(smartWallet.deployment.deployTransaction).toBe(txHash);
     });
 
     it('Should fail when relaying a Transaction', async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "importHelpers": true,
-    "target": "es5",
+    "target": "es6",
     "typeRoots": [
       "node_modules/@types"
     ],


### PR DESCRIPTION
## What

- Created a transaction history modal to be able to verify the transactions for each smart wallet

## Why

- With the current implementation, each time the users try to execute a transaction, they need to wait until it is confirmed (or rejected). To avoid this, we could provide the user with the link to the explorer.

## Refs

- [Jira issue](https://rsklabs.atlassian.net/browse/PP-171)
- https://github.com/rsksmart/rif-relay-client/pull/20
- https://github.com/rsksmart/rif-relay-common/pull/23
