### PR TITLE
PP-127: remove relayWorker and collectorContractfrom the transaction details

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "loglevel": "^1.8.0",
     "ethereumjs-tx": "~2.1.2",
-    "@rsksmart/rif-relay-client": "https://github.com/rsksmart/rif-relay-client#PP-94/revenue-sharing-model",
+    "@rsksmart/rif-relay-client": "https://github.com/rsksmart/rif-relay-client#PP-127/no-collector-field",
     "@rsksmart/rif-relay-common": "https://github.com/rsksmart/rif-relay-common#PP-94/revenue-sharing-model",
     "@rsksmart/rif-relay-contracts": "https://github.com/rsksmart/rif-relay-contracts#PP-94/revenue-sharing-model",
     "web3": "1.2.6",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "loglevel": "^1.8.0",
     "ethereumjs-tx": "~2.1.2",
-    "@rsksmart/rif-relay-client": "https://github.com/rsksmart/rif-relay-client#PP-127/no-collector-field",
+    "@rsksmart/rif-relay-client": "https://github.com/rsksmart/rif-relay-client#PP-94/revenue-sharing-model",
     "@rsksmart/rif-relay-common": "https://github.com/rsksmart/rif-relay-common#PP-94/revenue-sharing-model",
     "@rsksmart/rif-relay-contracts": "https://github.com/rsksmart/rif-relay-contracts#PP-94/revenue-sharing-model",
     "web3": "1.2.6",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -58,7 +58,6 @@ export interface RelayingTransactionOptions {
     value?: number;
     onlyPreferredRelays?: boolean;
     tokenAddress: string;
-    collectorContract?: string;
 }
 
 export interface RelayGasEstimationOptions {
@@ -66,7 +65,6 @@ export interface RelayGasEstimationOptions {
     smartWalletAddress: string;
     tokenFees: string;
     abiEncodedTx: string;
-    relayWorker: string;
     tokenAddress: string;
     onlyPreferredRelays?: boolean;
     callVerifier?: string;
@@ -74,5 +72,4 @@ export interface RelayGasEstimationOptions {
     isSmartWalletDeploy?: boolean;
     index?: string;
     recoverer?: string;
-    collectorContract?: string;
 }

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -318,8 +318,7 @@ export class DefaultRelayingServices implements RelayingServices {
             transactionDetails,
             value,
             onlyPreferredRelays,
-            tokenAddress,
-            collectorContract
+            tokenAddress
         } = options;
 
         log.debug('Checking if the wallet exists');
@@ -348,7 +347,6 @@ export class DefaultRelayingServices implements RelayingServices {
                     callForwarder: address,
                     data: unsignedTx.data,
                     tokenContract: tokenAddress,
-                    collectorContract: collectorContract,
                     tokenAmount: [null, undefined].includes(tokenAmount)
                         ? undefined
                         : this.web3Instance.utils.toWei(tokenAmount.toString()),
@@ -384,7 +382,6 @@ export class DefaultRelayingServices implements RelayingServices {
             smartWalletAddress,
             tokenFees,
             abiEncodedTx,
-            relayWorker,
             tokenAddress,
             onlyPreferredRelays,
             callVerifier,
@@ -435,19 +432,13 @@ export class DefaultRelayingServices implements RelayingServices {
             trxDetails.gas = toHex(internalCallCost);
 
             const tokenGas = (
-                await relayClient.estimateTokenTransferGas(
-                    trxDetails,
-                    relayWorker
-                )
+                await relayClient.estimateTokenTransferGas(trxDetails)
             ).toString();
             trxDetails.tokenGas = tokenGas;
         }
 
         const maxPossibleGasValue =
-            await relayClient.estimateMaxPossibleRelayGas(
-                trxDetails,
-                relayWorker
-            );
+            await relayClient.estimateMaxPossibleRelayGas(trxDetails);
         return this.calculateCostFromGas(maxPossibleGasValue);
     }
 
@@ -461,7 +452,6 @@ export class DefaultRelayingServices implements RelayingServices {
             smartWalletAddress,
             tokenFees,
             abiEncodedTx,
-            relayWorker,
             tokenAddress
         } = options;
 
@@ -481,8 +471,7 @@ export class DefaultRelayingServices implements RelayingServices {
 
         const maxPossibleGasValue =
             await this.relayProvider.relayClient.estimateMaxPossibleRelayGasWithLinearFit(
-                trxDetails,
-                relayWorker
+                trxDetails
             );
         return this.calculateCostFromGas(maxPossibleGasValue);
     }


### PR DESCRIPTION
## What

- removed collector field and relayworker from transaction details
-  removed relayworker from function calls

## Why

- collector and relayworker fields are no longer needed at this level

## Refs

- PP-94, PP-127
